### PR TITLE
Stop after 100 line/token errors

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const validate = require('./lib/validate');
+const validateSourceFile = require('./lib/validate');
 const Storage = require('@google-cloud/storage');
 
 let config = null;
@@ -35,7 +34,7 @@ exports.validateSourceFile = function(req, res) {
     res.status(500).send('URL not specified');
   }
 
-  validate(url, function(errors, sources) {
+  validateSourceFile(url, function(errors, sources) {
     const bucket = storage.bucket(config.STORAGE_BUCKET);
 
     // object names can't contain most symbols, so encode as a URI component

--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -47,6 +47,18 @@ function InvalidSourceMapFormatError(url, error) {
   this.resolutions = ['Everything is broken. Is this really a Source Map?'];
 }
 
+function LineNotFoundError(source, options) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.source = source;
+
+  const {line, column} = options;
+  this.line = line;
+  this.column = column;
+  this.message = 'Line not found in source file';
+  this.resolutions = [];
+}
+
 function BadTokenError(source, options) {
   Error.captureStackTrace(this, this.constructor);
   this.name = this.constructor.name;
@@ -58,16 +70,17 @@ function BadTokenError(source, options) {
   this.line = line;
   this.column = column;
 
-  this.message = 'Mismatched token in source map';
+  this.message = 'Expected token not in correct location';
   this.resolutions = [];
 }
 
 module.exports = {
-  SourceMapNotFoundError: SourceMapNotFoundError,
-  UnableToFetchError: UnableToFetchError,
-  UnableToFetchMinifiedError: UnableToFetchMinifiedError,
-  UnableToFetchSourceMapError: UnableToFetchSourceMapError,
-  InvalidSourceMapFormatError: InvalidSourceMapFormatError,
-  InvalidJSONError: InvalidJSONError,
-  BadTokenError: BadTokenError
+  SourceMapNotFoundError,
+  UnableToFetchError,
+  UnableToFetchMinifiedError,
+  UnableToFetchSourceMapError,
+  InvalidSourceMapFormatError,
+  InvalidJSONError,
+  LineNotFoundError,
+  BadTokenError
 };

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -196,7 +196,7 @@ describe('validateSourceFile', function() {
         assert.equal(errors[0].constructor, BadTokenError);
         assert.equal(
           errors[0].message,
-          'Mismatched token in source map'
+          'Expected token not in correct location'
         );
         done();
       });


### PR DESCRIPTION
I noticed that for large, production files, sourcemaps.io would return reports with 10s of thousands of errors – with the report itself weighing in as large as 10MB!

😆 