### PR TITLE
Display some errors as warnings ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # default to sourcemaps.io production values
 #
-GCLOUD_FN_NAME=validateSourceFile
+GCLOUD_FN_NAME=validateGeneratedFile
 GCLOUD_REGION=us-central1
 GCLOUD_VALIDATE_URL=https://${GCLOUD_REGION}-${GCLOUD_PROJECT}.cloudfunctions.net/${GCLOUD_FN_NAME}
 LOCAL_VALIDATE_URL=http://127.0.0.1:3001/${GCLOUD_FN_NAME}

--- a/client/src/views/Report.js
+++ b/client/src/views/Report.js
@@ -161,7 +161,7 @@ class Report extends Component {
               </h3>
               <ul>
                 {report.errors.map((err, index) => {
-                  return err.name === 'BadTokenError' ? BadTokenEntry(err, index) : Entry(err, index);
+                  return ['BadTokenError', 'BadColumnError'].includes(err.name) ? BadTokenEntry(err, index) : Entry(err, index);
                 })}
               </ul>
               <h3>

--- a/client/src/views/Report.js
+++ b/client/src/views/Report.js
@@ -168,7 +168,9 @@ class Report extends Component {
                 Warnings <span className="badge">{report.warnings.length}</span>
               </h3>
               <ul>
-                {report.warnings.map(Entry)}
+                {report.warnings.map((err, index) => {
+                  return ['BadTokenError', 'BadColumnError'].includes(err.name) ? BadTokenEntry(err, index) : Entry(err, index);
+                })}
               </ul>
             </div>}
       </div>;

--- a/server/dev.js
+++ b/server/dev.js
@@ -3,13 +3,13 @@
  */
 const express = require('express');
 const path = require('path');
-const {validateSourceFile} = require('.');
+const {validateGeneratedFile} = require('.');
 
 const PORT = 3001;
 
 const app = express();
 
-app.post('/validateSourceFile', validateSourceFile);
+app.post('/validateGeneratedFile', validateGeneratedFile);
 
 
 app.use('/fixtures', express.static(path.join('test', 'fixtures', 'build')));

--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,7 @@ exports.validateGeneratedFile = function (req, res) {
     res.status(500).send('URL not specified');
   }
 
-  validateGeneratedFile(url, (errors, sources) => {
+  validateGeneratedFile(url, (report, sources) => {
     const bucket = storage.bucket(config.STORAGE_BUCKET);
 
     // object names can't contain most symbols, so encode as a URI component
@@ -61,12 +61,12 @@ exports.validateGeneratedFile = function (req, res) {
       );
     });
 
-    const report = {
+    const jsonReport = {
       url,
-      errors,
+      errors: report.errors,
       sources: sources || [],
-      warnings: [] // TODO
+      warnings: report.warnings
     };
-    stream.end(JSON.stringify(report));
+    stream.end(JSON.stringify(jsonReport));
   });
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const {validateTargetFile} = require('./lib/validate');
+const {validateGeneratedFile} = require('./lib/validate');
 const Storage = require('@google-cloud/storage');
 
 let config = null;
@@ -27,7 +27,7 @@ const storage = Storage({
  * @param {object} event The Cloud Functions event.
  * @param {function} The callback function.
  */
-exports.validateSourceFile = function (req, res) {
+exports.validateGeneratedFile = function (req, res) {
   res.set('Access-Control-Allow-Origin', '*');
   res.set('Access-Control-Allow-Methods', 'POST');
 
@@ -36,7 +36,7 @@ exports.validateSourceFile = function (req, res) {
     res.status(500).send('URL not specified');
   }
 
-  validateTargetFile(url, (errors, sources) => {
+  validateGeneratedFile(url, (errors, sources) => {
     const bucket = storage.bucket(config.STORAGE_BUCKET);
 
     // object names can't contain most symbols, so encode as a URI component

--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -94,6 +94,10 @@ function BadTokenError(source, options) {
   this.resolutions = [];
 }
 
+function BadColumnError(source, options) {
+  BadTokenError.call(this, source, options);
+}
+
 module.exports = {
   SourceMapNotFoundError,
   UnableToFetchError,
@@ -105,5 +109,6 @@ module.exports = {
   LineNotFoundError,
   BadTokenError,
   BadContentError,
+  BadColumnError,
   ResourceTimeoutError
 };

--- a/server/lib/validate.js
+++ b/server/lib/validate.js
@@ -160,7 +160,12 @@ function validateMappings(sourceMapConsumer, generatedLines) {
     }
 
     const error = validateMapping(mapping, sourceLines, generatedLines);
-    if (error) {
+
+    // Treat bad column errors as warnings (since they'll work fine for
+    // most apps)
+    if (error instanceof BadColumnError) {
+      report.pushWarning(error);
+    } else if (error) {
       report.pushError(error);
     }
   });

--- a/server/lib/validate.js
+++ b/server/lib/validate.js
@@ -30,6 +30,7 @@ const {
   LineNotFoundError,
   BadTokenError,
   BadContentError,
+  BadColumnError,
   ResourceTimeoutError
 } = require('./errors');
 
@@ -74,6 +75,12 @@ function validateMapping(mapping, sourceLines, generatedLines) {
     return null;
   }
 
+  // If the line _contains_ the expected token somewhere, the source
+  // map will likely work fine (especially for Sentry).
+  const ErrorClass = origLine.indexOf(sourceToken) > -1
+    ? BadColumnError
+    : BadTokenError;
+
   const {generatedColumn} = mapping;
 
   let generatedLine;
@@ -91,7 +98,7 @@ function validateMapping(mapping, sourceLines, generatedLines) {
   // Take 100 chars of context around generated line
   const generatedContext = generatedLine.slice(generatedColumn - 50, generatedColumn + 50);
 
-  return new BadTokenError(mapping.source, {
+  return new ErrorClass(mapping.source, {
     token: sourceToken,
     expected: mapping.name,
     mapping: {

--- a/server/lib/validate.js
+++ b/server/lib/validate.js
@@ -165,7 +165,7 @@ function resolveUrl(baseUrl, targetUrl) {
 /**
  * Validates a target transpiled/minified file located at a given url
  */
-function validateTargetFile(url, callback) {
+function validateGeneratedFile(url, callback) {
   const errors = [];
   request(url, {timeout: MAX_TIMEOUT}, (error, response, body) => {
     if (error) {
@@ -334,7 +334,7 @@ function fetchSources(sourceMapConsumer, resolvedSources, callback) {
 }
 
 module.exports = {
-  validateTargetFile,
+  validateGeneratedFile,
   validateMappings,
   resolveSourceMapSource
 };

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -277,8 +277,9 @@ describe('validateTargetFile', () => {
 
         validateGeneratedFile(url, (report) => {
           assert.notEqual(report.errors.length, 0);
-          assert.equal(report.errors[0].constructor, BadColumnError);
-          assert.equal(report.errors[0].message, 'Expected token not in correct location');
+          assert.notEqual(report.warnings.length, 0);
+          assert.equal(report.warnings[0].constructor, BadColumnError);
+          assert.equal(report.warnings[0].message, 'Expected token not in correct location');
           done();
         });
       });

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -276,7 +276,7 @@ describe('validateTargetFile', () => {
           .reply(200, fs.readFileSync(mapFilePath, 'utf-8'));
 
         validateGeneratedFile(url, (report) => {
-          assert.notEqual(report.errors.length, 0);
+          assert.equal(report.errors.length, 0);
           assert.notEqual(report.warnings.length, 0);
           assert.equal(report.warnings[0].constructor, BadColumnError);
           assert.equal(report.warnings[0].message, 'Expected token not in correct location');


### PR DESCRIPTION
Also, instead of passing around multiple params like `errors`, `warnings`, and `sources` (resolved) between every callback, just uses a higher-level `Report` object.