### PR TITLE
fix: Everything

### DIFF
--- a/client/src/views/Home.tsx
+++ b/client/src/views/Home.tsx
@@ -7,13 +7,13 @@ const VALIDATE_URL = import.meta.env.REACT_APP_VALIDATE_URL;
 const TARGET_URL_PLACEHOLDER = 'http://code.jquery.com/jquery-1.9.1.min.js';
 
 interface ExampleProps {
-  name: string,
-  url: string,
-  version: string,
-  onClick: React.MouseEventHandler<HTMLAnchorElement>,
+  name: string;
+  url: string;
+  version: string;
+  onClick: React.MouseEventHandler<HTMLAnchorElement>;
 }
 
-function Example({name, url, version, onClick}: ExampleProps) {
+function Example({ name, url, version, onClick }: ExampleProps) {
   return (
     <li>
       <a href={url} onClick={onClick}>
@@ -51,13 +51,12 @@ export default function Home() {
   const [isLoading, setIsLoading] = useState(false);
 
   const navigate = useNavigate();
-  
+
   const handleSubmit = useCallback(() => {
-    const url = encodeURIComponent(targetUrl || TARGET_URL_PLACEHOLDER);
+    const url = targetUrl || TARGET_URL_PLACEHOLDER;
 
     setIsLoading(true);
 
-    // Encode the url again to match whats saved on the server
     fetch(`${VALIDATE_URL}?url=${encodeURIComponent(url)}`, {
       method: 'POST'
     }).then(response => {
@@ -74,10 +73,13 @@ export default function Home() {
   return (
     <div>
       <div className="row">
-        <form action="/validate" onSubmit={(event: React.FormEvent) => {
-          event.preventDefault();
-          handleSubmit();
-        }}>
+        <form
+          action="/validate"
+          onSubmit={(event: React.FormEvent) => {
+            event.preventDefault();
+            handleSubmit();
+          }}
+        >
           <div className="col-md-10 form-group">
             <input
               type="text"
@@ -101,7 +103,7 @@ export default function Home() {
           <Example
             key={index}
             {...example}
-            onClick={(event) => {
+            onClick={event => {
               event.preventDefault();
 
               setTargetUrl(example.url);

--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -169,6 +169,17 @@ class BadColumnError extends BadTokenError {
   }
 }
 
+class UnknownError extends Error {
+  resolutions: Array<string>;
+
+  constructor(url: string) {
+    super();
+    this.name = 'UnknownError';
+    this.message = `An unknown error occurred for url: ${url}`;
+    this.resolutions = ['Try again.'];
+  }
+}
+
 export {
   SourceMapNotFoundError,
   UnableToFetchError,
@@ -182,5 +193,6 @@ export {
   BadContentError,
   BadColumnError,
   ResourceTimeoutError,
-  ConnectionRefusedError as SocketRefusedError
+  ConnectionRefusedError as SocketRefusedError,
+  UnknownError
 };

--- a/server/src/lib/validateSourceMap.ts
+++ b/server/src/lib/validateSourceMap.ts
@@ -20,7 +20,8 @@ import {
   InvalidSourceMapFormatError,
   InvalidJSONError,
   BadContentError,
-  ResourceTimeoutError
+  ResourceTimeoutError,
+  UnknownError
 } from './errors';
 
 import { MAX_TIMEOUT } from './constants';
@@ -70,9 +71,11 @@ export default function validateSourceMap(
       if (error) {
         if (error.message === 'ESOCKETTIMEDOUT') {
           report.pushError(new ResourceTimeoutError(sourceMapUrl, MAX_TIMEOUT));
-          return void reportCallback(report);
+        } else {
+          report.pushError(new UnknownError(sourceMapUrl));
         }
-        return void console.error(error);
+        reportCallback(report);
+        return;
       }
 
       if (response && response.statusCode !== 200) {


### PR DESCRIPTION
- Don't double encode urls for resources
- Name default export so that the codebase is less confusing
- Actually end response on unknown errors
- Transmit to client if an unknown error occurs